### PR TITLE
Remove extract-domain dependency

### DIFF
--- a/packages/react-microlink/package.json
+++ b/packages/react-microlink/package.json
@@ -33,7 +33,6 @@
     "previsualization"
   ],
   "dependencies": {
-    "extract-domain": "~2.0.3",
     "nanoclamp": "~1.2.6"
   },
   "devDependencies": {

--- a/packages/react-microlink/src/components/Card/CardContent.js
+++ b/packages/react-microlink/src/components/Card/CardContent.js
@@ -1,9 +1,17 @@
+/* global URL */
+
 import React from 'react'
 import styled, { css } from 'styled-components'
-import extractDomain from 'extract-domain'
 import CardText from './CardText'
 
 import { media } from '../../utils'
+
+const REGEX_STRIP_WWW = /^www\./
+
+const getHostname = href => {
+  const { hostname } = new URL(href)
+  return hostname.replace(REGEX_STRIP_WWW, '')
+}
 
 const isLarge = cardSize => cardSize === 'large'
 
@@ -68,7 +76,7 @@ export default ({ title, description, url, cardSize, className }) => (
       <CardText lines={2}>{description}</CardText>
     </Description>
     <Url className='microlink_card__content_url'>
-      <CardText lines={1}>{extractDomain(url)}</CardText>
+      <CardText lines={1}>{getHostname(url)}</CardText>
     </Url>
   </Content>
 )

--- a/packages/react-microlink/stories/data.js
+++ b/packages/react-microlink/stories/data.js
@@ -9,7 +9,9 @@ export const urls = [
   'http://es.engadget.com/2017/10/23/meizu-m6-note-analisis-review-fotos',
   'https://www.nytimes.com/2017/09/19/learning/whats-going-on-in-this-graph-sept-19-2017.html',
   'https://gizmodo.com/drone-video-of-border-wall-prototypes-accidentally-show-1819710328',
-  'https://www.bbc.com/news/technology-40762328'
+  'https://www.bbc.com/news/technology-40762328',
+  'https://browserless.js.org',
+  'https://xn--vi8hl0c.ws/'
 ]
 
 export const urlsVideo = [


### PR DESCRIPTION
do the same using native `URL` and strip www

I note we can remove this dependency after read normalize-url implementation:
https://github.com/sindresorhus/normalize-url/blob/master/index.js#L118

Also I added `https://xn--vi8hl0c.ws/` into tests urls to keep in mind we don't convert from IDN to unicode:

https://github.com/sindresorhus/normalize-url/blob/master/index.js#L112

This could be done adding punycode or similar dependency, but it's a little heavy (https://bundlephobia.com/result?p=punycode@2.1.0) so I want investigate and found a workaround first

