### PR TITLE
Support single node as argument to microlink()

### DIFF
--- a/packages/microlinkjs/src/index.js
+++ b/packages/microlinkjs/src/index.js
@@ -22,7 +22,7 @@ const getDataAttributes = el => Object.keys(el.dataset).reduce((acc, key) => {
   return acc
 }, {})
 
-const getDOMSelector = selector => typeof selector === 'string' ? qa(selector) : selector
+const getDOMSelector = selector => typeof selector === 'string' ? qa(selector) : [].concat(selector)
 
 module.exports = (selector, opts) => {
   opts = Object.assign({}, DEFAULT_OPTS, opts)


### PR DESCRIPTION
Addresses issue #113 