### PR TITLE
fix: use transparent background for png images

### DIFF
--- a/packages/react/src/components/Card/CardMedia/wrap.js
+++ b/packages/react/src/components/Card/CardMedia/wrap.js
@@ -16,7 +16,7 @@ const mobileStyle = media.mobile`
 `
 
 export default styled('div')`
-  background: #e1e8ed no-repeat center center / cover;
+  background: transparent no-repeat center center / cover;
   display: block;
   flex: 0 0 125px;
   overflow: hidden;

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "husky": "latest",
     "prettier-standard": "latest",
-    "rollup": "~1.10.1",
+    "rollup": "~1.11.3",
     "rollup-plugin-commonjs": "latest",
     "rollup-plugin-filesize": "latest",
     "rollup-plugin-node-resolve": "latest",


### PR DESCRIPTION
**before**

![Screenshot 2019-05-01 at 00 04 46](https://user-images.githubusercontent.com/2096101/56996437-d989b500-6ba4-11e9-9013-0002fd633179.png)

**after**

![Screenshot 2019-05-01 at 00 04 58](https://user-images.githubusercontent.com/2096101/56996438-d989b500-6ba4-11e9-8cef-289d0931429e.png)
