### PR TITLE
build: enable image proxy for any https url

### DIFF
--- a/packages/react/src/components/Card/CardMedia/Video.js
+++ b/packages/react/src/components/Card/CardMedia/Video.js
@@ -34,12 +34,15 @@ const Video = ({
   ...props
 }) => {
   const mediaProps = useMemo(
-    () => ({
-      className: `${classNames.media} ${classNames.video}`,
-      src: videoUrl,
-      poster: imageProxy(imageUrl),
-      playsInline
-    }),
+    () => {
+      const mediaProps = {
+        className: `${classNames.media} ${classNames.video}`,
+        src: videoUrl,
+        playsInline
+      }
+      if (imageUrl) mediaProps.poster = imageProxy(imageUrl)
+      return mediaProps
+    },
     [imageUrl, loop, muted, playsInline, videoUrl]
   )
 

--- a/packages/react/src/utils/index.js
+++ b/packages/react/src/utils/index.js
@@ -1,9 +1,6 @@
 import { css } from 'styled-components'
 import { fetchFromApi, getApiUrl as createApiUrl } from '@microlink/mql'
 
-const REGEX_HTTPS = /^https/
-const REGEX_LOCALHOST = /http:\/\/localhost/
-
 const isSSR = typeof window === 'undefined'
 
 export const isFunction = fn => typeof fn === 'function'
@@ -63,13 +60,7 @@ export const isLarge = cardSize => cardSize === 'large'
 
 export const isSmall = cardSize => cardSize === 'small'
 
-export const imageProxy = url => {
-  if (!url || REGEX_LOCALHOST.test(url) || REGEX_HTTPS.test(url)) return url
-  return `https://images.weserv.nl/?url=${encodeURI(url).replace(
-    'http://',
-    ''
-  )}`
-}
+export const imageProxy = url => `https://images.weserv.nl/?url=${encodeURI(url)}&l=9&af&il`
 
 export const isLazySupported = !isSSR && 'IntersectionObserver' in window
 


### PR DESCRIPTION
images.weserv.nl releases API v5 and they are serving around 6 millions request per hour. That's totally crazy!

I think it's enough stable and confident to be used as default image proxy.

On this PR:

- Enable image proxy for any http(s) URL.
- Setup [compression level](https://images.weserv.nl/docs/format.html#compression-level) to max possible.
- Setup [adaptative filter](https://images.weserv.nl/docs/format.html#adaptive-filter) for PNGs images.
- Setup [progressive filter](https://images.weserv.nl/docs/format.html#interlace-progressive) for GIF/JPEG images
