### PR TITLE
build: move rootNode logic out of vanilla

### DIFF
--- a/packages/vanilla/src/index.js
+++ b/packages/vanilla/src/index.js
@@ -28,12 +28,6 @@ function forEach (list, fn) {
 
 function microlink (selector, opts, rootNode) {
   return forEach(getDOMSelector(selector), function (el) {
-    if (!rootNode) {
-      rootNode = document.createElement('div')
-      rootNode.className = 'microlink_vanilla_dom'
-      el.parentNode.insertBefore(rootNode, el)
-    }
-
     ReactDOM.render(
       React.createElement(
         Microlink,
@@ -45,10 +39,8 @@ function microlink (selector, opts, rootNode) {
           parseObject(el.dataset)
         )
       ),
-      rootNode
+      rootNode || el
     )
-
-    el.remove()
   })
 }
 


### PR DESCRIPTION
This change is motivated since the vanilla version needs to mount the microlink card into the node selected using a dom query selector.

On the other hand, Vue/Angular needs to reuse the same node.

So the thing I did is to remove the rootNode logic out of the vanilla bundle, meaning:


- The node used for mounting the component will be `rootNode || el`
- For reusing the mounted node, just setup the logic **before** and **after** call vanilla bundle.

This PR is not completed; Need to update the Vue/Angular logic for doing that workflow:

1) Create `rootNode` and pass it to `microlink/vanilla`.
2) do cleanup action (`el.remove()` after exec `microlink/vanilla`.
