### PR TITLE
fix: avoid create element dynamically

### DIFF
--- a/packages/react/src/components/Card/CardWrap.js
+++ b/packages/react/src/components/Card/CardWrap.js
@@ -1,9 +1,9 @@
 import { createElement, forwardRef, useContext } from 'react'
 import styled, { css } from 'styled-components'
 
-import { media, isLarge } from '../../utils'
-import { font, animation, speed } from '../../theme'
 import { GlobalContext } from '../../context/GlobalState'
+import { font, animation, speed } from '../../theme'
+import { media, isLarge } from '../../utils'
 
 const HEIGHT = '382px'
 
@@ -61,7 +61,6 @@ const baseStyle = css(
   transition-duration: ${speed.medium};
   transition-timing-function: ${animation.medium};
 
-
   &:active,
   &:hover {
     outline: 0;
@@ -69,29 +68,32 @@ const baseStyle = css(
 `
 )
 
-const createEl = el =>
-  styled(el)(
-    baseStyle,
-    ({ isLoading, contrast }) => !isLoading && !contrast && hoverStyle,
-    ({ cardSize }) => isLarge(cardSize) && largeStyle,
-    ({ direction }) => direction === 'rtl' && rtlStyle,
-    ({ backgroundColor, color, contrast }) =>
-      contrast && color && backgroundColor && contrastStyle,
-    ({ backgroundColor, color, contrast }) =>
-      contrast && (!color || !backgroundColor) && hoverStyle
-  )
+const Element = styled('a')(
+  baseStyle,
+  ({ isLoading, contrast }) => !isLoading && !contrast && hoverStyle,
+  ({ cardSize }) => isLarge(cardSize) && largeStyle,
+  ({ direction }) => direction === 'rtl' && rtlStyle,
+  ({ backgroundColor, color, contrast }) =>
+    contrast && color && backgroundColor && contrastStyle,
+  ({ backgroundColor, color, contrast }) =>
+    contrast && (!color || !backgroundColor) && hoverStyle
+)
 
 const CardWrap = forwardRef(({ href, rel, target, ...restProps }, ref) => {
   const {
     state: { backgroundColor, color, title },
     props: { size: cardSize }
   } = useContext(GlobalContext)
-  const props = { ...restProps, backgroundColor, cardSize, color, ref, title }
 
-  return createElement(
-    createEl(props.as),
-    props.as === 'a' ? { href, rel, target, ...props } : props
-  )
+  return createElement(Element, {
+    ...(restProps.as === 'a' ? { href, rel, target } : undefined),
+    ...restProps,
+    backgroundColor,
+    cardSize,
+    color,
+    ref,
+    title
+  })
 })
 
 CardWrap.defaultProps = {

--- a/packages/react/stories/__snapshots__/stories.test.js.snap
+++ b/packages/react/stories/__snapshots__/stories.test.js.snap
@@ -25,7 +25,7 @@ exports[`Storyshots media audio 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,7 +49,7 @@ exports[`Storyshots media audio 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -104,7 +104,7 @@ exports[`Storyshots media audio 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -115,13 +115,13 @@ exports[`Storyshots media audio 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -135,7 +135,7 @@ exports[`Storyshots media audio 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -146,17 +146,17 @@ exports[`Storyshots media audio 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -171,8 +171,8 @@ exports[`Storyshots media audio 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -182,19 +182,19 @@ exports[`Storyshots media audio 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -205,8 +205,8 @@ exports[`Storyshots media audio 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -224,7 +224,7 @@ exports[`Storyshots media audio 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -232,13 +232,13 @@ exports[`Storyshots media audio 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -247,7 +247,7 @@ exports[`Storyshots media audio 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -257,35 +257,10 @@ exports[`Storyshots media audio 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -316,35 +291,7 @@ exports[`Storyshots media audio 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -371,9 +318,34 @@ exports[`Storyshots media audio 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -395,11 +367,7 @@ exports[`Storyshots media audio 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -438,20 +406,20 @@ exports[`Storyshots media audio 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://open.spotify.com/track/1W2919zs8SBCLTrOB1ftQT?si=4PcqgjH5RlWCvB5q4ukdnw"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -459,23 +427,23 @@ exports[`Storyshots media audio 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://open.spotify.com/track/1W2919zs8SBCLTrOB1ftQT?si=4PcqgjH5RlWCvB5q4ukdnw"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -542,8 +510,8 @@ exports[`Storyshots media iframe 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -553,8 +521,8 @@ exports[`Storyshots media iframe 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -565,8 +533,8 @@ exports[`Storyshots media iframe 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -590,35 +558,10 @@ exports[`Storyshots media iframe 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -647,6 +590,31 @@ exports[`Storyshots media iframe 1`] = `
 .c2:active,
 .c2:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -728,7 +696,7 @@ exports[`Storyshots media image 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -752,7 +720,7 @@ exports[`Storyshots media image 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -807,7 +775,7 @@ exports[`Storyshots media image 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -818,13 +786,13 @@ exports[`Storyshots media image 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -838,7 +806,7 @@ exports[`Storyshots media image 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -849,17 +817,17 @@ exports[`Storyshots media image 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -874,8 +842,8 @@ exports[`Storyshots media image 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -885,19 +853,19 @@ exports[`Storyshots media image 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -908,8 +876,8 @@ exports[`Storyshots media image 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -927,7 +895,7 @@ exports[`Storyshots media image 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -935,13 +903,13 @@ exports[`Storyshots media image 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -950,7 +918,7 @@ exports[`Storyshots media image 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -960,35 +928,10 @@ exports[`Storyshots media image 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -1019,35 +962,7 @@ exports[`Storyshots media image 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -1074,9 +989,34 @@ exports[`Storyshots media image 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -1098,11 +1038,7 @@ exports[`Storyshots media image 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -1141,20 +1077,20 @@ exports[`Storyshots media image 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -1162,23 +1098,23 @@ exports[`Storyshots media image 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -1213,7 +1149,7 @@ exports[`Storyshots media logo 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1237,7 +1173,7 @@ exports[`Storyshots media logo 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1292,7 +1228,7 @@ exports[`Storyshots media logo 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -1303,13 +1239,13 @@ exports[`Storyshots media logo 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1323,7 +1259,7 @@ exports[`Storyshots media logo 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -1334,17 +1270,17 @@ exports[`Storyshots media logo 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1359,8 +1295,8 @@ exports[`Storyshots media logo 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -1370,19 +1306,19 @@ exports[`Storyshots media logo 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -1393,8 +1329,8 @@ exports[`Storyshots media logo 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -1412,7 +1348,7 @@ exports[`Storyshots media logo 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -1420,13 +1356,13 @@ exports[`Storyshots media logo 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -1435,7 +1371,7 @@ exports[`Storyshots media logo 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -1445,35 +1381,10 @@ exports[`Storyshots media logo 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -1504,35 +1415,7 @@ exports[`Storyshots media logo 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -1559,9 +1442,34 @@ exports[`Storyshots media logo 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -1583,11 +1491,7 @@ exports[`Storyshots media logo 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -1626,20 +1530,20 @@ exports[`Storyshots media logo 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -1647,23 +1551,23 @@ exports[`Storyshots media logo 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -1698,7 +1602,7 @@ exports[`Storyshots media screenshot 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1722,7 +1626,7 @@ exports[`Storyshots media screenshot 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1777,7 +1681,7 @@ exports[`Storyshots media screenshot 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -1788,13 +1692,13 @@ exports[`Storyshots media screenshot 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1808,7 +1712,7 @@ exports[`Storyshots media screenshot 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -1819,17 +1723,17 @@ exports[`Storyshots media screenshot 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -1844,8 +1748,8 @@ exports[`Storyshots media screenshot 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -1855,19 +1759,19 @@ exports[`Storyshots media screenshot 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -1878,8 +1782,8 @@ exports[`Storyshots media screenshot 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -1897,7 +1801,7 @@ exports[`Storyshots media screenshot 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -1905,13 +1809,13 @@ exports[`Storyshots media screenshot 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -1920,7 +1824,7 @@ exports[`Storyshots media screenshot 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -1930,35 +1834,10 @@ exports[`Storyshots media screenshot 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -1989,35 +1868,7 @@ exports[`Storyshots media screenshot 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -2044,9 +1895,34 @@ exports[`Storyshots media screenshot 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -2068,11 +1944,7 @@ exports[`Storyshots media screenshot 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -2111,20 +1983,20 @@ exports[`Storyshots media screenshot 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -2132,23 +2004,23 @@ exports[`Storyshots media screenshot 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -2183,7 +2055,7 @@ exports[`Storyshots media video 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2207,7 +2079,7 @@ exports[`Storyshots media video 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2262,7 +2134,7 @@ exports[`Storyshots media video 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -2273,13 +2145,13 @@ exports[`Storyshots media video 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2293,7 +2165,7 @@ exports[`Storyshots media video 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -2304,17 +2176,17 @@ exports[`Storyshots media video 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2329,8 +2201,8 @@ exports[`Storyshots media video 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -2340,19 +2212,19 @@ exports[`Storyshots media video 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -2363,8 +2235,8 @@ exports[`Storyshots media video 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -2382,7 +2254,7 @@ exports[`Storyshots media video 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -2390,13 +2262,13 @@ exports[`Storyshots media video 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -2405,7 +2277,7 @@ exports[`Storyshots media video 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -2415,35 +2287,10 @@ exports[`Storyshots media video 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -2474,35 +2321,7 @@ exports[`Storyshots media video 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -2529,9 +2348,34 @@ exports[`Storyshots media video 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -2553,11 +2397,7 @@ exports[`Storyshots media video 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -2596,20 +2436,20 @@ exports[`Storyshots media video 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.facebook.com/natgeo/videos/10156364216738951/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -2617,23 +2457,23 @@ exports[`Storyshots media video 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.facebook.com/natgeo/videos/10156364216738951/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -2668,7 +2508,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2692,7 +2532,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2747,7 +2587,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -2758,13 +2598,13 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2778,7 +2618,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -2789,17 +2629,17 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -2814,8 +2654,8 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -2825,19 +2665,19 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -2848,8 +2688,8 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -2867,7 +2707,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -2875,13 +2715,13 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -2890,7 +2730,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -2900,35 +2740,10 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -2959,35 +2774,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -3014,9 +2801,34 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -3038,11 +2850,7 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -3081,20 +2889,20 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.facebook.com/natgeo/videos/10156364216738951/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -3102,23 +2910,23 @@ exports[`Storyshots props autoPlay (disabled) 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.facebook.com/natgeo/videos/10156364216738951/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -3153,7 +2961,7 @@ exports[`Storyshots props contrast 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3177,7 +2985,7 @@ exports[`Storyshots props contrast 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3232,7 +3040,7 @@ exports[`Storyshots props contrast 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -3243,13 +3051,13 @@ exports[`Storyshots props contrast 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -3263,7 +3071,7 @@ exports[`Storyshots props contrast 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -3274,17 +3082,17 @@ exports[`Storyshots props contrast 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -3299,8 +3107,8 @@ exports[`Storyshots props contrast 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -3310,19 +3118,19 @@ exports[`Storyshots props contrast 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -3333,8 +3141,8 @@ exports[`Storyshots props contrast 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -3352,7 +3160,7 @@ exports[`Storyshots props contrast 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -3360,13 +3168,13 @@ exports[`Storyshots props contrast 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -3375,7 +3183,7 @@ exports[`Storyshots props contrast 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -3385,35 +3193,10 @@ exports[`Storyshots props contrast 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -3452,43 +3235,7 @@ exports[`Storyshots props contrast 1`] = `
   border-color: rgba(136,153,166,0.5);
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  -webkit-transition-property: background,border-color;
-  transition-property: background,border-color;
-  will-change: background,border-color;
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c10:hover {
-  background: #f5f8fa;
-  border-color: rgba(136,153,166,0.5);
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -3518,14 +3265,39 @@ exports[`Storyshots props contrast 1`] = `
   will-change: background,border-color;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
 }
 
-.c14:hover {
+.c13:hover {
   background: #f5f8fa;
   border-color: rgba(136,153,166,0.5);
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -3547,11 +3319,7 @@ exports[`Storyshots props contrast 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -3590,20 +3358,20 @@ exports[`Storyshots props contrast 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -3611,23 +3379,23 @@ exports[`Storyshots props contrast 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -3662,7 +3430,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3686,7 +3454,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3741,7 +3509,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -3752,13 +3520,13 @@ exports[`Storyshots props controls (disabled) 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -3772,7 +3540,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -3783,17 +3551,17 @@ exports[`Storyshots props controls (disabled) 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -3808,8 +3576,8 @@ exports[`Storyshots props controls (disabled) 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -3819,19 +3587,19 @@ exports[`Storyshots props controls (disabled) 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -3842,8 +3610,8 @@ exports[`Storyshots props controls (disabled) 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -3861,7 +3629,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -3869,13 +3637,13 @@ exports[`Storyshots props controls (disabled) 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -3884,7 +3652,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -3894,35 +3662,10 @@ exports[`Storyshots props controls (disabled) 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -3953,35 +3696,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -4008,9 +3723,34 @@ exports[`Storyshots props controls (disabled) 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -4032,11 +3772,7 @@ exports[`Storyshots props controls (disabled) 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -4075,20 +3811,20 @@ exports[`Storyshots props controls (disabled) 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.facebook.com/natgeo/videos/10156364216738951/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -4096,23 +3832,23 @@ exports[`Storyshots props controls (disabled) 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.facebook.com/natgeo/videos/10156364216738951/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -4147,7 +3883,7 @@ exports[`Storyshots props default 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4171,7 +3907,7 @@ exports[`Storyshots props default 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4226,7 +3962,7 @@ exports[`Storyshots props default 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -4237,13 +3973,13 @@ exports[`Storyshots props default 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -4257,7 +3993,7 @@ exports[`Storyshots props default 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -4268,17 +4004,17 @@ exports[`Storyshots props default 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -4293,8 +4029,8 @@ exports[`Storyshots props default 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -4304,19 +4040,19 @@ exports[`Storyshots props default 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -4327,8 +4063,8 @@ exports[`Storyshots props default 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -4346,7 +4082,7 @@ exports[`Storyshots props default 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -4354,13 +4090,13 @@ exports[`Storyshots props default 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -4369,7 +4105,7 @@ exports[`Storyshots props default 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -4379,35 +4115,10 @@ exports[`Storyshots props default 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -4438,35 +4149,7 @@ exports[`Storyshots props default 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -4493,9 +4176,34 @@ exports[`Storyshots props default 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -4517,11 +4225,7 @@ exports[`Storyshots props default 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -4560,20 +4264,20 @@ exports[`Storyshots props default 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -4581,23 +4285,23 @@ exports[`Storyshots props default 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -4632,7 +4336,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4656,7 +4360,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4711,7 +4415,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -4722,13 +4426,13 @@ exports[`Storyshots props direction + contrast 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -4742,7 +4446,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -4753,17 +4457,17 @@ exports[`Storyshots props direction + contrast 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -4778,8 +4482,8 @@ exports[`Storyshots props direction + contrast 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -4789,19 +4493,19 @@ exports[`Storyshots props direction + contrast 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -4812,8 +4516,8 @@ exports[`Storyshots props direction + contrast 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -4831,7 +4535,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -4839,13 +4543,13 @@ exports[`Storyshots props direction + contrast 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -4854,7 +4558,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -4864,35 +4568,10 @@ exports[`Storyshots props direction + contrast 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -4934,46 +4613,7 @@ exports[`Storyshots props direction + contrast 1`] = `
   border-color: rgba(136,153,166,0.5);
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-  -webkit-transition-property: background,border-color;
-  transition-property: background,border-color;
-  will-change: background,border-color;
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c10:hover {
-  background: #f5f8fa;
-  border-color: rgba(136,153,166,0.5);
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -5006,14 +4646,39 @@ exports[`Storyshots props direction + contrast 1`] = `
   will-change: background,border-color;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
 }
 
-.c14:hover {
+.c13:hover {
   background: #f5f8fa;
   border-color: rgba(136,153,166,0.5);
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -5035,11 +4700,7 @@ exports[`Storyshots props direction + contrast 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -5078,20 +4739,20 @@ exports[`Storyshots props direction + contrast 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="rtl"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -5099,23 +4760,23 @@ exports[`Storyshots props direction + contrast 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="rtl"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -5150,7 +4811,7 @@ exports[`Storyshots props direction 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5174,7 +4835,7 @@ exports[`Storyshots props direction 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5229,7 +4890,7 @@ exports[`Storyshots props direction 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -5240,13 +4901,13 @@ exports[`Storyshots props direction 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -5260,7 +4921,7 @@ exports[`Storyshots props direction 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -5271,17 +4932,17 @@ exports[`Storyshots props direction 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -5296,8 +4957,8 @@ exports[`Storyshots props direction 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -5307,19 +4968,19 @@ exports[`Storyshots props direction 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -5330,8 +4991,8 @@ exports[`Storyshots props direction 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -5349,7 +5010,7 @@ exports[`Storyshots props direction 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -5357,13 +5018,13 @@ exports[`Storyshots props direction 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -5372,7 +5033,7 @@ exports[`Storyshots props direction 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -5382,35 +5043,10 @@ exports[`Storyshots props direction 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -5444,38 +5080,7 @@ exports[`Storyshots props direction 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  -webkit-flex-direction: row-reverse;
-  -ms-flex-direction: row-reverse;
-  flex-direction: row-reverse;
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -5505,9 +5110,34 @@ exports[`Storyshots props direction 1`] = `
   flex-direction: column-reverse;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -5529,11 +5159,7 @@ exports[`Storyshots props direction 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -5572,20 +5198,20 @@ exports[`Storyshots props direction 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="rtl"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -5593,23 +5219,23 @@ exports[`Storyshots props direction 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="rtl"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -5645,7 +5271,7 @@ Array [
   align-items: stretch;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5669,7 +5295,7 @@ Array [
   align-items: center;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5724,7 +5350,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c12 {
+.c11 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -5735,13 +5361,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c12::before {
+.c11::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c12::after {
+.c11::after {
   content: '';
   position: absolute;
   left: 0;
@@ -5755,7 +5381,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c16 {
+.c15 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -5766,17 +5392,17 @@ Array [
   flex: 1;
 }
 
-.c16::before {
+.c15::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c16::before {
+.c15::before {
   padding-bottom: 0;
 }
 
-.c16::after {
+.c15::after {
   content: '';
   position: absolute;
   left: 0;
@@ -5791,8 +5417,8 @@ Array [
 }
 
 .c6 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c8 {
@@ -5802,19 +5428,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c14 {
+.c13 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c9 {
@@ -5825,8 +5451,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -5844,7 +5470,7 @@ Array [
   top: 14px;
 }
 
-.c18 {
+.c17 {
   height: 33px;
   width: 95%;
   display: block;
@@ -5852,13 +5478,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c18::before {
+.c17::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -5867,7 +5493,7 @@ Array [
   background: #fff;
 }
 
-.c18::before {
+.c17::before {
   top: 14px;
 }
 
@@ -5877,10 +5503,70 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
+}
+
+.c3 {
+  max-width: 500px;
+  background-color: #fff;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #e1e8ed;
+  overflow: hidden;
+  color: #181919;
+  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  opacity: 1;
+  position: relative;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
+  transition-timing-function: cubic-bezier(.25,.8,.25,1);
+}
+
+.c3:active,
+.c3:hover {
+  outline: 0;
+}
+
+.c14 {
+  max-width: 500px;
+  background-color: #fff;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #e1e8ed;
+  overflow: hidden;
+  color: #181919;
+  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  opacity: 1;
+  position: relative;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
+  transition-timing-function: cubic-bezier(.25,.8,.25,1);
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 382px;
+}
+
+.c14:active,
+.c14:hover {
+  outline: 0;
 }
 
 .c0 {
@@ -5922,94 +5608,6 @@ Array [
   margin-bottom: 32px;
 }
 
-.c3 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c3:active,
-.c3:hover {
-  outline: 0;
-}
-
-.c11 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c11:active,
-.c11:hover {
-  outline: 0;
-}
-
-.c15 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 382px;
-}
-
-.c15:active,
-.c15:hover {
-  outline: 0;
-}
-
 @media (max-width:48em) {
   .c5 {
     -webkit-flex: 0 0 92px;
@@ -6029,21 +5627,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c15 {
+  .c14 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -6089,20 +5675,20 @@ Array [
       </div>
     </a>
     <a
-      className="c11 microlink_card c4"
+      className="c3 microlink_card c4"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
       target="_blank"
     >
       <div
-        className="c12 c6 microlink_card__media microlink_card__media_image"
+        className="c11 c6 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c13 microlink_card__content"
+        className="c12 microlink_card__content"
       >
         <span
-          className="c14"
+          className="c13"
         />
         <span
           className="c10"
@@ -6110,23 +5696,23 @@ Array [
       </div>
     </a>
     <a
-      className="c15 microlink_card c4"
+      className="c14 microlink_card c4"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
       target="_blank"
     >
       <div
-        className="c16 c6 microlink_card__media microlink_card__media_image"
+        className="c15 c6 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c17 microlink_card__content"
+        className="c16 microlink_card__content"
       >
         <span
           className="c8"
         />
         <span
-          className="c18"
+          className="c17"
         />
         <span
           className="c10"
@@ -6158,7 +5744,7 @@ Array [
   align-items: stretch;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6182,7 +5768,7 @@ Array [
   align-items: center;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6237,7 +5823,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c12 {
+.c11 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -6248,13 +5834,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c12::before {
+.c11::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c12::after {
+.c11::after {
   content: '';
   position: absolute;
   left: 0;
@@ -6268,7 +5854,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c16 {
+.c15 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -6279,17 +5865,17 @@ Array [
   flex: 1;
 }
 
-.c16::before {
+.c15::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c16::before {
+.c15::before {
   padding-bottom: 0;
 }
 
-.c16::after {
+.c15::after {
   content: '';
   position: absolute;
   left: 0;
@@ -6304,8 +5890,8 @@ Array [
 }
 
 .c6 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c8 {
@@ -6315,19 +5901,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c14 {
+.c13 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c9 {
@@ -6338,8 +5924,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -6357,7 +5943,7 @@ Array [
   top: 14px;
 }
 
-.c18 {
+.c17 {
   height: 33px;
   width: 95%;
   display: block;
@@ -6365,13 +5951,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c18::before {
+.c17::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -6380,7 +5966,7 @@ Array [
   background: #fff;
 }
 
-.c18::before {
+.c17::before {
   top: 14px;
 }
 
@@ -6390,10 +5976,70 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
+}
+
+.c3 {
+  max-width: 500px;
+  background-color: #fff;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #e1e8ed;
+  overflow: hidden;
+  color: #181919;
+  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  opacity: 1;
+  position: relative;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
+  transition-timing-function: cubic-bezier(.25,.8,.25,1);
+}
+
+.c3:active,
+.c3:hover {
+  outline: 0;
+}
+
+.c14 {
+  max-width: 500px;
+  background-color: #fff;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #e1e8ed;
+  overflow: hidden;
+  color: #181919;
+  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  opacity: 1;
+  position: relative;
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
+  transition-timing-function: cubic-bezier(.25,.8,.25,1);
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 382px;
+}
+
+.c14:active,
+.c14:hover {
+  outline: 0;
 }
 
 .c0 {
@@ -6435,94 +6081,6 @@ Array [
   margin-bottom: 32px;
 }
 
-.c3 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c3:active,
-.c3:hover {
-  outline: 0;
-}
-
-.c11 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c11:active,
-.c11:hover {
-  outline: 0;
-}
-
-.c15 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  height: 382px;
-}
-
-.c15:active,
-.c15:hover {
-  outline: 0;
-}
-
 @media (max-width:48em) {
   .c5 {
     -webkit-flex: 0 0 92px;
@@ -6542,19 +6100,7 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c15 {
+  .c14 {
     height: calc(382px * 7/9);
   }
 }
@@ -6604,20 +6150,20 @@ Array [
       </div>
     </a>
     <a
-      className="c11 microlink_card c4"
+      className="c3 microlink_card c4"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
       target="_blank"
     >
       <div
-        className="c12 c6 microlink_card__media microlink_card__media_image"
+        className="c11 c6 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c13 microlink_card__content"
+        className="c12 microlink_card__content"
       >
         <span
-          className="c14"
+          className="c13"
         />
         <span
           className="c10"
@@ -6625,23 +6171,23 @@ Array [
       </div>
     </a>
     <a
-      className="c15 microlink_card c4"
+      className="c14 microlink_card c4"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
       target="_blank"
     >
       <div
-        className="c16 c6 microlink_card__media microlink_card__media_image"
+        className="c15 c6 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c17 microlink_card__content"
+        className="c16 microlink_card__content"
       >
         <span
           className="c8"
         />
         <span
-          className="c18"
+          className="c17"
         />
         <span
           className="c10"
@@ -6677,7 +6223,7 @@ exports[`Storyshots props loading 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6701,7 +6247,7 @@ exports[`Storyshots props loading 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6756,7 +6302,7 @@ exports[`Storyshots props loading 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -6767,13 +6313,13 @@ exports[`Storyshots props loading 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -6787,7 +6333,7 @@ exports[`Storyshots props loading 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -6798,17 +6344,17 @@ exports[`Storyshots props loading 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -6823,8 +6369,8 @@ exports[`Storyshots props loading 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -6834,19 +6380,19 @@ exports[`Storyshots props loading 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -6857,8 +6403,8 @@ exports[`Storyshots props loading 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -6876,7 +6422,7 @@ exports[`Storyshots props loading 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -6884,13 +6430,13 @@ exports[`Storyshots props loading 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -6899,7 +6445,7 @@ exports[`Storyshots props loading 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -6909,35 +6455,10 @@ exports[`Storyshots props loading 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -6968,35 +6489,7 @@ exports[`Storyshots props loading 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -7023,9 +6516,34 @@ exports[`Storyshots props loading 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -7047,11 +6565,7 @@ exports[`Storyshots props loading 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -7090,20 +6604,20 @@ exports[`Storyshots props loading 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://microlink.io"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -7111,23 +6625,23 @@ exports[`Storyshots props loading 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://microlink.io"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -7162,7 +6676,7 @@ exports[`Storyshots setData function 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7186,7 +6700,7 @@ exports[`Storyshots setData function 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7241,7 +6755,7 @@ exports[`Storyshots setData function 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -7252,13 +6766,13 @@ exports[`Storyshots setData function 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -7272,7 +6786,7 @@ exports[`Storyshots setData function 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -7283,17 +6797,17 @@ exports[`Storyshots setData function 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -7308,8 +6822,8 @@ exports[`Storyshots setData function 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -7319,19 +6833,19 @@ exports[`Storyshots setData function 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -7342,8 +6856,8 @@ exports[`Storyshots setData function 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -7361,7 +6875,7 @@ exports[`Storyshots setData function 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -7369,13 +6883,13 @@ exports[`Storyshots setData function 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -7384,7 +6898,7 @@ exports[`Storyshots setData function 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -7394,35 +6908,10 @@ exports[`Storyshots setData function 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -7453,35 +6942,7 @@ exports[`Storyshots setData function 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -7508,9 +6969,34 @@ exports[`Storyshots setData function 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -7532,11 +7018,7 @@ exports[`Storyshots setData function 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -7575,20 +7057,20 @@ exports[`Storyshots setData function 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://microlink.io"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -7596,23 +7078,23 @@ exports[`Storyshots setData function 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://microlink.io"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -7647,7 +7129,7 @@ exports[`Storyshots setData object 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7671,7 +7153,7 @@ exports[`Storyshots setData object 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7726,7 +7208,7 @@ exports[`Storyshots setData object 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -7737,13 +7219,13 @@ exports[`Storyshots setData object 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -7757,7 +7239,7 @@ exports[`Storyshots setData object 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -7768,17 +7250,17 @@ exports[`Storyshots setData object 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -7793,8 +7275,8 @@ exports[`Storyshots setData object 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -7804,19 +7286,19 @@ exports[`Storyshots setData object 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -7827,8 +7309,8 @@ exports[`Storyshots setData object 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -7846,7 +7328,7 @@ exports[`Storyshots setData object 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -7854,13 +7336,13 @@ exports[`Storyshots setData object 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -7869,7 +7351,7 @@ exports[`Storyshots setData object 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -7879,35 +7361,10 @@ exports[`Storyshots setData object 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -7938,35 +7395,7 @@ exports[`Storyshots setData object 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -7993,9 +7422,34 @@ exports[`Storyshots setData object 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -8017,11 +7471,7 @@ exports[`Storyshots setData object 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -8060,20 +7510,20 @@ exports[`Storyshots setData object 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://microlink.io"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -8081,23 +7531,23 @@ exports[`Storyshots setData object 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://microlink.io"
     rel="noopener noreferrer"
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -8165,8 +7615,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -8176,8 +7626,8 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -8188,8 +7638,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -8213,35 +7663,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -8270,6 +7695,31 @@ Array [
 .c2:active,
 .c2:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -8380,8 +7830,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -8391,8 +7841,8 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -8403,8 +7853,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -8428,35 +7878,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -8485,6 +7910,31 @@ Array [
 .c2:active,
 .c2:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -8568,7 +8018,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8592,7 +8042,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8647,7 +8097,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -8658,13 +8108,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -8678,7 +8128,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -8689,17 +8139,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -8714,8 +8164,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -8725,19 +8175,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -8748,8 +8198,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -8767,7 +8217,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -8775,13 +8225,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -8790,7 +8240,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -8800,35 +8250,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -8859,35 +8284,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -8914,9 +8311,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -8938,29 +8360,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -9003,7 +8405,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://www.apple.com/music/"
       rel="noopener noreferrer"
@@ -9016,13 +8418,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -9030,7 +8432,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://www.apple.com/music/"
       rel="noopener noreferrer"
@@ -9043,16 +8445,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -9084,7 +8486,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9108,7 +8510,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9163,7 +8565,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -9174,13 +8576,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -9194,7 +8596,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -9205,17 +8607,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -9230,8 +8632,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -9241,19 +8643,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -9264,8 +8666,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -9283,7 +8685,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -9291,13 +8693,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -9306,7 +8708,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -9316,35 +8718,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -9375,35 +8752,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -9430,9 +8779,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -9454,29 +8828,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -9519,7 +8873,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -9532,13 +8886,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -9546,7 +8900,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -9559,16 +8913,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -9600,7 +8954,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9624,7 +8978,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9679,7 +9033,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -9690,13 +9044,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -9710,7 +9064,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -9721,17 +9075,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -9746,8 +9100,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -9757,19 +9111,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -9780,8 +9134,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -9799,7 +9153,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -9807,13 +9161,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -9822,7 +9176,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -9832,35 +9186,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -9891,35 +9220,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -9946,9 +9247,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -9970,27 +9296,7 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -10035,7 +9341,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -10048,13 +9354,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -10062,7 +9368,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -10075,16 +9381,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -10121,7 +9427,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10145,7 +9451,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10200,7 +9506,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -10211,13 +9517,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -10231,7 +9537,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -10242,17 +9548,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -10267,8 +9573,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -10278,19 +9584,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -10301,8 +9607,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -10320,7 +9626,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -10328,13 +9634,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -10343,7 +9649,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -10353,35 +9659,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -10412,35 +9693,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -10467,9 +9720,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -10491,53 +9769,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -10580,7 +9814,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://www.apple.com/music/"
       rel="noopener noreferrer"
@@ -10593,13 +9827,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -10607,7 +9841,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://www.apple.com/music/"
       rel="noopener noreferrer"
@@ -10620,16 +9854,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -10661,7 +9895,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10685,7 +9919,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10740,7 +9974,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -10751,13 +9985,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -10771,7 +10005,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -10782,17 +10016,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -10807,8 +10041,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -10818,19 +10052,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -10841,8 +10075,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -10860,7 +10094,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -10868,13 +10102,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -10883,7 +10117,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -10893,35 +10127,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -10952,35 +10161,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -11007,9 +10188,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -11031,53 +10237,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -11120,7 +10282,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -11133,13 +10295,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -11147,7 +10309,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -11160,16 +10322,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -11201,7 +10363,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11225,7 +10387,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11280,7 +10442,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -11291,13 +10453,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -11311,7 +10473,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -11322,17 +10484,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -11347,8 +10509,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -11358,19 +10520,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -11381,8 +10543,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -11400,7 +10562,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -11408,13 +10570,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -11423,7 +10585,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -11433,35 +10595,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -11492,35 +10629,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -11547,9 +10656,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -11571,53 +10705,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -11660,7 +10750,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -11673,13 +10763,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -11687,7 +10777,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -11700,16 +10790,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -11741,7 +10831,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11765,7 +10855,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11820,7 +10910,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -11831,13 +10921,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -11851,7 +10941,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -11862,17 +10952,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -11887,8 +10977,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -11898,19 +10988,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -11921,8 +11011,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -11940,7 +11030,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -11948,13 +11038,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -11963,7 +11053,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -11973,35 +11063,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -12032,35 +11097,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -12087,9 +11124,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -12111,53 +11173,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -12200,7 +11218,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -12213,13 +11231,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -12227,7 +11245,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -12240,16 +11258,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -12281,7 +11299,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12305,7 +11323,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12360,7 +11378,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -12371,13 +11389,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -12391,7 +11409,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -12402,17 +11420,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -12427,8 +11445,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -12438,19 +11456,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -12461,8 +11479,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -12480,7 +11498,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -12488,13 +11506,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -12503,7 +11521,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -12513,35 +11531,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -12572,35 +11565,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -12627,9 +11592,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -12651,53 +11641,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -12740,7 +11686,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -12753,13 +11699,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -12767,7 +11713,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -12780,16 +11726,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -12821,7 +11767,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12845,7 +11791,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12900,7 +11846,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -12911,13 +11857,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -12931,7 +11877,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -12942,17 +11888,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -12967,8 +11913,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -12978,19 +11924,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -13001,8 +11947,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -13020,7 +11966,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -13028,13 +11974,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -13043,7 +11989,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -13053,35 +11999,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -13112,35 +12033,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -13167,9 +12060,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -13191,51 +12109,7 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -13280,7 +12154,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -13293,13 +12167,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -13307,7 +12181,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -13320,16 +12194,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -13365,7 +12239,7 @@ exports[`Storyshots style misc 1`] = `
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13389,7 +12263,7 @@ exports[`Storyshots style misc 1`] = `
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13444,7 +12318,7 @@ exports[`Storyshots style misc 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -13455,13 +12329,13 @@ exports[`Storyshots style misc 1`] = `
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -13475,7 +12349,7 @@ exports[`Storyshots style misc 1`] = `
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -13486,17 +12360,17 @@ exports[`Storyshots style misc 1`] = `
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -13511,8 +12385,8 @@ exports[`Storyshots style misc 1`] = `
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -13522,19 +12396,19 @@ exports[`Storyshots style misc 1`] = `
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -13545,8 +12419,8 @@ exports[`Storyshots style misc 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -13564,7 +12438,7 @@ exports[`Storyshots style misc 1`] = `
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -13572,13 +12446,13 @@ exports[`Storyshots style misc 1`] = `
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -13587,7 +12461,7 @@ exports[`Storyshots style misc 1`] = `
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -13597,35 +12471,10 @@ exports[`Storyshots style misc 1`] = `
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -13656,35 +12505,7 @@ exports[`Storyshots style misc 1`] = `
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -13711,9 +12532,34 @@ exports[`Storyshots style misc 1`] = `
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -13735,11 +12581,7 @@ exports[`Storyshots style misc 1`] = `
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -13785,7 +12627,7 @@ exports[`Storyshots style misc 1`] = `
     </div>
   </a>
   <a
-    className="c10 microlink_card c3"
+    className="c2 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
@@ -13799,13 +12641,13 @@ exports[`Storyshots style misc 1`] = `
     target="_blank"
   >
     <div
-      className="c11 c5 microlink_card__media microlink_card__media_image"
+      className="c10 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c12 microlink_card__content"
+      className="c11 microlink_card__content"
     >
       <span
-        className="c13"
+        className="c12"
       />
       <span
         className="c9"
@@ -13813,7 +12655,7 @@ exports[`Storyshots style misc 1`] = `
     </div>
   </a>
   <a
-    className="c14 microlink_card c3"
+    className="c13 microlink_card c3"
     direction="ltr"
     href="https://www.apple.com/music/"
     rel="noopener noreferrer"
@@ -13827,16 +12669,16 @@ exports[`Storyshots style misc 1`] = `
     target="_blank"
   >
     <div
-      className="c15 c5 microlink_card__media microlink_card__media_image"
+      className="c14 c5 microlink_card__media microlink_card__media_image"
     />
     <div
-      className="c16 microlink_card__content"
+      className="c15 microlink_card__content"
     >
       <span
         className="c7"
       />
       <span
-        className="c17"
+        className="c16"
       />
       <span
         className="c9"
@@ -13872,7 +12714,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13896,7 +12738,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13951,7 +12793,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -13962,13 +12804,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -13982,7 +12824,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -13993,17 +12835,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -14018,8 +12860,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -14029,19 +12871,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -14052,8 +12894,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -14071,7 +12913,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -14079,13 +12921,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -14094,7 +12936,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -14104,35 +12946,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -14163,35 +12980,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -14218,9 +13007,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -14242,53 +13056,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -14331,7 +13101,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://www.apple.com/music/"
       rel="noopener noreferrer"
@@ -14344,13 +13114,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -14358,7 +13128,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://www.apple.com/music/"
       rel="noopener noreferrer"
@@ -14371,16 +13141,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -14412,7 +13182,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14436,7 +13206,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14491,7 +13261,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -14502,13 +13272,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -14522,7 +13292,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -14533,17 +13303,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -14558,8 +13328,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -14569,19 +13339,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -14592,8 +13362,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -14611,7 +13381,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -14619,13 +13389,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -14634,7 +13404,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -14644,35 +13414,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -14703,35 +13448,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -14758,9 +13475,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -14782,53 +13524,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -14871,7 +13569,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -14884,13 +13582,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -14898,7 +13596,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -14911,16 +13609,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -14952,7 +13650,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14976,7 +13674,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15031,7 +13729,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -15042,13 +13740,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -15062,7 +13760,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -15073,17 +13771,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -15098,8 +13796,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -15109,19 +13807,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -15132,8 +13830,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -15151,7 +13849,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -15159,13 +13857,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -15174,7 +13872,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -15184,35 +13882,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -15243,35 +13916,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -15298,9 +13943,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -15322,53 +13992,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -15411,7 +14037,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -15424,13 +14050,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -15438,7 +14064,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -15451,16 +14077,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -15492,7 +14118,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15516,7 +14142,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15571,7 +14197,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -15582,13 +14208,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -15602,7 +14228,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -15613,17 +14239,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -15638,8 +14264,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -15649,19 +14275,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -15672,8 +14298,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -15691,7 +14317,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -15699,13 +14325,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -15714,7 +14340,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -15724,35 +14350,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -15783,35 +14384,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -15838,9 +14411,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -15862,53 +14460,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -15951,7 +14505,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -15964,13 +14518,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -15978,7 +14532,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -15991,16 +14545,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -16032,7 +14586,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16056,7 +14610,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16111,7 +14665,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -16122,13 +14676,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -16142,7 +14696,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -16153,17 +14707,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -16178,8 +14732,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -16189,19 +14743,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -16212,8 +14766,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -16231,7 +14785,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -16239,13 +14793,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -16254,7 +14808,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -16264,35 +14818,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -16323,35 +14852,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -16378,9 +14879,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -16402,53 +14928,9 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
-}
-
-@media (max-width:48em) {
-
 }
 
 <div
@@ -16491,7 +14973,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -16504,13 +14986,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -16518,7 +15000,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -16531,16 +15013,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"
@@ -16572,7 +15054,7 @@ Array [
   align-items: stretch;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16596,7 +15078,7 @@ Array [
   align-items: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16651,7 +15133,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c11 {
+.c10 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -16662,13 +15144,13 @@ Array [
   flex: 0 0 48px;
 }
 
-.c11::before {
+.c10::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c11::after {
+.c10::after {
   content: '';
   position: absolute;
   left: 0;
@@ -16682,7 +15164,7 @@ Array [
   transition: opacity 150ms cubic-bezier(.25,.8,.25,1);
 }
 
-.c15 {
+.c14 {
   background: transparent no-repeat center center / cover;
   display: block;
   overflow: hidden;
@@ -16693,17 +15175,17 @@ Array [
   flex: 1;
 }
 
-.c15::before {
+.c14::before {
   content: '';
   padding-bottom: 100%;
   display: block;
 }
 
-.c15::before {
+.c14::before {
   padding-bottom: 0;
 }
 
-.c15::after {
+.c14::after {
   content: '';
   position: absolute;
   left: 0;
@@ -16718,8 +15200,8 @@ Array [
 }
 
 .c5 {
-  -webkit-animation: PfPAm 1.25s linear infinite;
-  animation: PfPAm 1.25s linear infinite;
+  -webkit-animation: kHwByW 1.25s linear infinite;
+  animation: kHwByW 1.25s linear infinite;
 }
 
 .c7 {
@@ -16729,19 +15211,19 @@ Array [
   background: #e1e8ed;
   margin: 2px 0 8px;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
-.c13 {
+.c12 {
   height: 16px;
   width: 75%;
   display: block;
   background: #e1e8ed;
   margin: 0 20px 0 0;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
 }
 
 .c8 {
@@ -16752,8 +15234,8 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
@@ -16771,7 +15253,7 @@ Array [
   top: 14px;
 }
 
-.c17 {
+.c16 {
   height: 33px;
   width: 95%;
   display: block;
@@ -16779,13 +15261,13 @@ Array [
   margin-bottom: 12px;
   opacity: 0.8;
   position: relative;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: 0.125s;
   animation-delay: 0.125s;
 }
 
-.c17::before {
+.c16::before {
   content: '';
   position: absolute;
   left: -1px;
@@ -16794,7 +15276,7 @@ Array [
   background: #fff;
 }
 
-.c17::before {
+.c16::before {
   top: 14px;
 }
 
@@ -16804,35 +15286,10 @@ Array [
   display: block;
   background: #e1e8ed;
   opacity: 0.8;
-  -webkit-animation: bmjNQl .75s linear infinite;
-  animation: bmjNQl .75s linear infinite;
+  -webkit-animation: ibPKPZ .75s linear infinite;
+  animation: ibPKPZ .75s linear infinite;
   -webkit-animation-delay: .25s;
   animation-delay: .25s;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 32px;
-  margin-bottom: 32px;
-}
-
-.c0:not(:last-child):not(:only-child) {
-  border-bottom: 1px solid #e0e0e0;
-}
-
-.c1 {
-  color: #0366d6;
-  margin-bottom: 32px;
-}
-
-.c3:not(:last-child):not(:only-child) {
-  margin-bottom: 32px;
 }
 
 .c2 {
@@ -16863,35 +15320,7 @@ Array [
   outline: 0;
 }
 
-.c10 {
-  max-width: 500px;
-  background-color: #fff;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #e1e8ed;
-  overflow: hidden;
-  color: #181919;
-  font-family: InterUI,-apple-system,BlinkMacSystemFont,'Helvetica Neue','Segoe UI',Oxygen,Ubuntu,Cantarell,'Open Sans',sans-serif;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  opacity: 1;
-  position: relative;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(.25,.8,.25,1);
-  transition-timing-function: cubic-bezier(.25,.8,.25,1);
-}
-
-.c10:active,
-.c10:hover {
-  outline: 0;
-}
-
-.c14 {
+.c13 {
   max-width: 500px;
   background-color: #fff;
   border-width: 1px;
@@ -16918,9 +15347,34 @@ Array [
   height: 382px;
 }
 
-.c14:active,
-.c14:hover {
+.c13:active,
+.c13:hover {
   outline: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 32px;
+  margin-bottom: 32px;
+}
+
+.c0:not(:last-child):not(:only-child) {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.c1 {
+  color: #0366d6;
+  margin-bottom: 32px;
+}
+
+.c3:not(:last-child):not(:only-child) {
+  margin-bottom: 32px;
 }
 
 @media (max-width:48em) {
@@ -16942,51 +15396,7 @@ Array [
 }
 
 @media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-
-}
-
-@media (max-width:48em) {
-  .c14 {
+  .c13 {
     height: calc(382px * 7/9);
   }
 }
@@ -17031,7 +15441,7 @@ Array [
       </div>
     </a>
     <a
-      className="c10 microlink_card c3"
+      className="c2 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -17044,13 +15454,13 @@ Array [
       target="_blank"
     >
       <div
-        className="c11 c5 microlink_card__media microlink_card__media_image"
+        className="c10 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c12 microlink_card__content"
+        className="c11 microlink_card__content"
       >
         <span
-          className="c13"
+          className="c12"
         />
         <span
           className="c9"
@@ -17058,7 +15468,7 @@ Array [
       </div>
     </a>
     <a
-      className="c14 microlink_card c3"
+      className="c13 microlink_card c3"
       direction="ltr"
       href="https://microlink.io"
       rel="noopener noreferrer"
@@ -17071,16 +15481,16 @@ Array [
       target="_blank"
     >
       <div
-        className="c15 c5 microlink_card__media microlink_card__media_image"
+        className="c14 c5 microlink_card__media microlink_card__media_image"
       />
       <div
-        className="c16 microlink_card__content"
+        className="c15 microlink_card__content"
       >
         <span
           className="c7"
         />
         <span
-          className="c17"
+          className="c16"
         />
         <span
           className="c9"


### PR DESCRIPTION
so `styled-components` is showing this warning:

```
styled-components.browser.esm.js:1347 The component styled.a with the id of "sc-pRtAn" has been created dynamically.
You may see this warning because you've called styled inside another component.
To resolve this only create new StyledComponents outside of any render method and function component
```

and it's correct, we were creating the element dynamically, so I refactor it to take the advantages of `as` prop tag 🙂