### PR TITLE
Add `as` prop to Vue & Angular integrations

### DIFF
--- a/packages/angular/src/microlink/microlink.component.ts
+++ b/packages/angular/src/microlink/microlink.component.ts
@@ -31,7 +31,12 @@ export class MicrolinkComponent implements AfterViewInit, OnChanges {
     anchor.href = this.url
     anchor.innerHTML = this.url
 
-    microlink(anchor, this.options, nativeElement)
+    const options = {
+      ...this.options,
+      as: 'a'
+    }
+
+    microlink(anchor, options, nativeElement)
   }
 
   ngAfterViewInit () {

--- a/packages/vue/src/index.js
+++ b/packages/vue/src/index.js
@@ -27,7 +27,7 @@ export const Microlink = Vue.component('Microlink', {
       const anchor = document.createElement('a')
       anchor.href = this.url
       anchor.innerHTML = this.url
-      microlink(anchor, this.parameters, cardSpace)
+      microlink(anchor, this.options, cardSpace)
     }
   },
 
@@ -41,14 +41,19 @@ export const Microlink = Vue.component('Microlink', {
   },
 
   computed: {
-    parameters () {
-      return Object.keys(this.$attrs).reduce(
+    options () {
+      const opts = Object.keys(this.$attrs).reduce(
         (acc, value) =>
           value.startsWith('data-')
             ? acc
             : { ...acc, [camelCase(value)]: this.$attrs[value] },
         Vue.microlinkGlobalOptions || {}
       )
+
+      return {
+        ...opts,
+        as: 'a'
+      }
     }
   },
 


### PR DESCRIPTION
+ Add `as` prop to Vue & Angular integrations, to ensure cards render as links
+ Rename vue "parameters" → "options"