### PR TITLE
fix: linter warnings

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -68,38 +68,6 @@ const Card = props => {
     [isLazyEnabled, hasIntersected]
   )
 
-  const toFetchData = useCallback(() => {
-    if (canFetchData) {
-      setLoading(true)
-
-      const fetch = fetchData
-        ? fetchFromApi(apiUrl, apiUrlProps)
-        : Promise.resolve({})
-
-      fetch
-        .then(({ data }) => mergeData(data))
-        .catch(error => {
-          setLoading(false)
-          setIsError(true)
-          console.error(`
-┌───────────────┐
-│ Microlink SDK │
-└───────────────┘
-
-${error.description}
-
-${JSON.stringify(error.data)}
-
-id   ${error.headers['x-request-id']}
-uri  ${error.url}
-code ${error.code} (${error.statusCode})
-
-microlink.io/${error.code.toLowerCase()}
-`)
-        })
-    }
-  }, [apiUrl, canFetchData, setData, apiUrlProps.headers['x-api-key'], url])
-
   const mergeData = useCallback(
     fetchedData => {
       const payload = isFunction(setData)
@@ -153,10 +121,42 @@ microlink.io/${error.code.toLowerCase()}
 
       setLoading(false)
     },
-    [mediaProps, setData]
+    [updateState, mediaProps, setData]
   )
 
-  useEffect(toFetchData, [url, setData, hasIntersected])
+  const toFetchData = useCallback(() => {
+    if (canFetchData) {
+      setLoading(true)
+
+      const fetch = fetchData
+        ? fetchFromApi(apiUrl, apiUrlProps)
+        : Promise.resolve({})
+
+      fetch
+        .then(({ data }) => mergeData(data))
+        .catch(error => {
+          setLoading(false)
+          setIsError(true)
+          console.error(`
+┌───────────────┐
+│ Microlink SDK │
+└───────────────┘
+
+${error.description}
+
+${JSON.stringify(error.data)}
+
+id   ${error.headers['x-request-id']}
+uri  ${error.url}
+code ${error.code} (${error.statusCode})
+
+microlink.io/${error.code.toLowerCase()}
+`)
+        })
+    }
+  }, [apiUrlProps, fetchData, apiUrl, mergeData, canFetchData])
+
+  useEffect(toFetchData, [toFetchData, url, setData, hasIntersected])
 
   const isLoading = isLoadingUndefined ? loadingState : loading
 


### PR DESCRIPTION
These changes are motivated by Next.js linter:

```
$ npx next lint

./src/index.js
101:6  Warning: React Hook useCallback has missing dependencies: 'apiUrlProps', 'fetchData', and 'mergeData'. Either include them or remove the dependency array.  react-hooks/exhaustive-deps
101:38  Warning: React Hook useCallback has a complex expression in the dependency array. Extract it to a separate variable so it can be statically checked.  react-hooks/exhaustive-deps
156:5  Warning: React Hook useCallback has a missing dependency: 'updateState'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
159:3  Warning: React Hook useEffect has a missing dependency: 'toFetchData'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
```

Related: https://github.com/microlinkhq/sdk/pull/297/files