### PR TITLE
fix: linter warning

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -58,8 +58,10 @@ const Card = props => {
     [lazy]
   )
   const lazyOptions = useMemo(() => (isObject(lazy) ? lazy : undefined), [lazy])
-  const [hasIntersected, cardRef] = useIntersectionObserver(
+  const cardRef = React.useRef(null)
+  const hasIntersected = useIntersectionObserver(
     isLazyEnabled,
+    cardRef,
     lazyOptions
   )
 
@@ -156,7 +158,7 @@ microlink.io/${error.code.toLowerCase()}
     }
   }, [apiUrlProps, fetchData, apiUrl, mergeData, canFetchData])
 
-  useEffect(toFetchData, [url, setData, hasIntersected])
+  useEffect(toFetchData, [url, toFetchData, setData, hasIntersected])
 
   const isLoading = isLoadingUndefined ? loadingState : loading
 
@@ -194,7 +196,6 @@ microlink.io/${error.code.toLowerCase()}
       className={`${classNames.main} ${className}`.trim()}
       href={url}
       $isLoading={isLoading}
-      ref={cardRef}
       {...restProps}
     >
       {isLoading ? (

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -1,11 +1,12 @@
 /* eslint-disable multiline-ternary */
 
 import React, {
-  useState,
-  useEffect,
   useCallback,
+  useContext,
+  useEffect,
   useMemo,
-  useContext
+  useRef,
+  useState
 } from 'react'
 
 import PropTypes from 'prop-types'
@@ -58,7 +59,7 @@ const Card = props => {
     [lazy]
   )
   const lazyOptions = useMemo(() => (isObject(lazy) ? lazy : undefined), [lazy])
-  const cardRef = React.useRef(null)
+  const cardRef = useRef(null)
   const hasIntersected = useIntersectionObserver(
     isLazyEnabled,
     cardRef,

--- a/packages/react/src/utils/hooks.js
+++ b/packages/react/src/utils/hooks.js
@@ -1,30 +1,23 @@
 /* global IntersectionObserver */
 
-import { useCallback, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-export const useIntersectionObserver = (enabled, options) => {
+export const useIntersectionObserver = (enabled, ref, options) => {
   const [hasIntersected, setHasIntersected] = useState(false)
 
-  const refCallback = useCallback(
-    node => {
-      if (enabled) {
-        const onIntersect = ([entry], self) => {
-          if (entry.isIntersecting) {
-            setHasIntersected(true)
-            self.unobserve(entry.target)
-          }
+  useEffect(() => {
+    if (enabled && ref.current) {
+      const onIntersect = ([entry], self) => {
+        if (entry.isIntersecting) {
+          setHasIntersected(true)
+          self.unobserve(entry.target)
         }
-        const observer = new IntersectionObserver(onIntersect, options)
-
-        if (node !== null) {
-          observer.observe(node)
-        }
-      } else {
-        setHasIntersected(true)
       }
-    },
-    [enabled, options]
-  )
+      const observer = new IntersectionObserver(onIntersect, options)
+      observer.observe(ref.current)
+      return () => observer.disconnect()
+    }
+  }, [ref, enabled, options])
 
-  return [hasIntersected, refCallback]
+  return hasIntersected
 }


### PR DESCRIPTION
I noted this warning

```
  162:3  warning  React Hook useEffect has a missing dependency: 'toFetchData'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```

We excluded `toFetchData` from the hook dependencies because otherwise it creates an infinite loop. I was digging what is causing that and I noted it comes from `useIntersectionObserver` since it returns a `ref` and it's being attached to a `CardWrap` element, creating the loop.

I think our `useIntersectionObserver` is based on this one:
https://github.com/uidotdev/usehooks/blob/dfa6623fcc2dcad3b466def4e0495b3f38af962b/index.js#L512

What I did for fixing this is to simply pas `ref` as argument, similar to this implementation:
https://github.com/streamich/react-use/blob/e27c1930da8b94a2c570954786aa68a3dc5624be/src/useIntersection.ts#L4
