### PR TITLE
chore: use background longhands in wrap to preserve image in ssr

### DIFF
--- a/packages/react/src/components/Card/CardMedia/Wrap.js
+++ b/packages/react/src/components/Card/CardMedia/Wrap.js
@@ -26,7 +26,10 @@ const mediaSizeStyles = {
 }
 
 const StyledWrap = styled('div')`
-  background: transparent no-repeat center center / cover;
+  background-color: transparent;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
   display: block;
   overflow: hidden;
   height: auto;


### PR DESCRIPTION
The `background:` shorthand on StyledWrap resets background-image, so when SSR class order flips (parent rule emitted after the child ImageWrap rule), the card image disappears in production while still working in dev.

Swap the shorthand for background-color/repeat/position/size longhands so ImageWrap's background-image survives regardless of CSS source order.